### PR TITLE
#5: add model bake-off example

### DIFF
--- a/examples/01_bakeoff.py
+++ b/examples/01_bakeoff.py
@@ -1,0 +1,118 @@
+"""
+Model bake-off: compare several estimators on the same dataset.
+
+Runs 5-fold cross-validation on the Digits dataset for three scikit-learn
+classifiers, logs each as its own MLflow run via ``skore.Project``, and
+prints a ranking that surfaces the stability-vs-mean tradeoff — the
+highest-mean model is not always the most stable across folds.
+
+Run:
+
+    uv run python examples/01_bakeoff.py
+
+Override defaults via environment variables:
+
+    PROJECT=my-bakeoff TRACKING_URI=http://localhost:5000 \
+        uv run python examples/01_bakeoff.py
+"""
+
+import os
+
+from sklearn.datasets import load_digits
+from sklearn.ensemble import HistGradientBoostingClassifier, RandomForestClassifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import StandardScaler
+
+from skore import Project, compare, evaluate
+
+# Configuration — override via environment variables or edit directly
+PROJECT = os.environ.get("PROJECT", "bakeoff-01")
+TRACKING_URI = os.environ.get("TRACKING_URI", "sqlite:///mlflow.db")
+
+# Metric used for the ranking punchline (must appear in the summarize() output)
+METRIC = "Accuracy"
+
+
+def build_estimators():
+    """Return a dict of slug -> scikit-learn estimator for the bake-off."""
+    return {
+        "hgb": HistGradientBoostingClassifier(random_state=0),
+        "logreg": Pipeline(
+            [
+                ("scaler", StandardScaler()),
+                ("clf", LogisticRegression(max_iter=1000, random_state=0)),
+            ]
+        ),
+        "rf": RandomForestClassifier(random_state=0),
+    }
+
+
+def per_fold_accuracy(report):
+    """Return the per-fold accuracy values from a CrossValidationReport."""
+    # accuracy(aggregate=None) returns a DataFrame with one row (Accuracy)
+    # and one column per fold under a model-name top level.
+    frame = report.metrics.accuracy(aggregate=None)
+    return frame.iloc[0].astype(float).to_numpy()
+
+
+def main():
+    # 1. Load the dataset
+    X, y = load_digits(return_X_y=True, as_frame=True)
+
+    # 2. Open the MLflow-backed skore project
+    project = Project(PROJECT, mode="mlflow", tracking_uri=TRACKING_URI)
+
+    # 3. Evaluate each estimator with 5-fold CV and persist as its own run
+    estimators = build_estimators()
+    reports = {}
+    for slug, estimator in estimators.items():
+        print(f"Evaluating {slug}...")
+        report = evaluate(estimator, X, y, splitter=5)
+        project.put(slug, report)
+        reports[slug] = report
+
+    # 4. Build a ComparisonReport to surface per-fold metric distributions
+    comparison = compare(reports)
+    print("\n=== ComparisonReport: aggregated metrics ===")
+    print(comparison.metrics.summarize().frame())
+
+    # 5. Rank by (mean, std) on the chosen metric
+    stats = {}
+    for slug, report in reports.items():
+        folds = per_fold_accuracy(report)
+        stats[slug] = (float(folds.mean()), float(folds.std(ddof=1)))
+
+    ranked = sorted(stats.items(), key=lambda kv: kv[1][0], reverse=True)
+
+    print(f"\n=== Ranking by mean {METRIC} (5-fold CV) ===")
+    print(f"{'rank':<5}{'model':<10}{'mean':>10}{'std':>10}")
+    for i, (slug, (mean, std)) in enumerate(ranked, start=1):
+        print(f"{i:<5}{slug:<10}{mean:>10.4f}{std:>10.4f}")
+
+    # 6. Stability-vs-mean punchline
+    top_slug, (top_mean, top_std) = ranked[0]
+    most_stable_slug, (stable_mean, stable_std) = min(
+        stats.items(), key=lambda kv: kv[1][1]
+    )
+    if most_stable_slug != top_slug and stable_std > 0:
+        ratio = top_std / stable_std
+        print(
+            f"\nNote: {top_slug} has the top mean {METRIC.lower()} "
+            f"({top_mean:.4f}) but {most_stable_slug} has ~{ratio:.1f}x "
+            f"tighter per-fold spread (std {stable_std:.4f} vs {top_std:.4f})."
+        )
+    else:
+        print(
+            f"\nNote: {top_slug} leads on both mean ({top_mean:.4f}) "
+            f"and per-fold stability (std {top_std:.4f}) for this run."
+        )
+
+    # 7. Confirm the MLflow runs that were logged
+    summary = project.summarize()
+    print(f"\nLogged {len(summary)} MLflow run(s) in experiment '{PROJECT}'.")
+    print(summary[["key", "report_type", "learner", "ml_task", "dataset"]])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Closes #5

## Summary

Adds `examples/01_bakeoff.py`: a model bake-off that compares three
scikit-learn classifiers on the Digits dataset using 5-fold cross-validation
through `skore.evaluate(..., splitter=5)`, logs each estimator as its own
MLflow run via `skore.Project(mode="mlflow")`, builds a `ComparisonReport`
for the per-fold view, and prints a ranking that surfaces the
stability-vs-mean tradeoff.

- Estimators: `HistGradientBoostingClassifier`, `LogisticRegression`
  (wrapped in a `StandardScaler` pipeline), `RandomForestClassifier`.
- Slug-keyed `project.put("hgb", ...)` / `project.put("logreg", ...)` /
  `project.put("rf", ...)` produces one MLflow run per estimator.
- `compare({"hgb": r1, "logreg": r2, "rf": r3})` produces a
  `ComparisonReport` with clean column labels.
- Ranking line prints `(mean, std)` of the per-fold Accuracy
  (`report.metrics.accuracy(aggregate=None)`), then a one-liner comparing
  the top-mean model against the most stable model with the actual std
  ratio.

## Ranking from an actual run

```
=== Ranking by mean Accuracy (5-fold CV) ===
rank model           mean       std
1    rf            0.9377    0.0290
2    hgb           0.9349    0.0185
3    logreg        0.9204    0.0336

Note: rf has the top mean accuracy (0.9377) but hgb has ~1.6x tighter per-fold spread (std 0.0185 vs 0.0290).
```

## Judgment calls

- **Dataset: `load_digits` (sklearn built-in).** Iris is too small to
  reliably expose the stability-vs-mean tradeoff with default
  hyper-parameters — in several runs RF leads on both mean and stability,
  so the punchline flattens. Digits (1797 samples, 10 classes) reliably
  shows RF winning on mean while HGB holds a tighter per-fold spread,
  which is exactly the punchline the issue calls for. Staying on an
  sklearn built-in also keeps the example reproducible without an
  OpenML network round-trip.
- **Ranking metric: Accuracy.** Matches what `ComparisonReport.summarize`
  surfaces by default for a multiclass problem and keeps the ranking
  line readable.
- **Per-fold extraction.** `CrossValidationReport.metrics.summarize()`
  on the installed `skore==0.15` only returns aggregated values; the
  per-fold values come from `report.metrics.accuracy(aggregate=None)`.

## Test plan
- [x] `uv run python examples/01_bakeoff.py` completes without error.
- [x] The MLflow experiment contains 3 runs (one per estimator).
- [x] Printed ranking shows mean and std per model plus the tradeoff one-liner.
- [x] `mlflow.db` / `mlruns/` are not committed.
- [x] `git status` showed only `examples/01_bakeoff.py` before commit.