### PR TITLE
#11: add GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,66 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: ${{ matrix.os }} / py${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Cache dataset downloads
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cache/skrub
+            ~/scikit_learn_data
+          key: datasets-${{ matrix.os }}-py${{ matrix.python-version }}-v1
+          restore-keys: |
+            datasets-${{ matrix.os }}-py${{ matrix.python-version }}-
+            datasets-${{ matrix.os }}-
+
+      - name: Install dependencies
+        shell: bash
+        run: uv sync --frozen
+
+      - name: Run plot_mlflow_backend.py
+        shell: bash
+        timeout-minutes: 5
+        run: uv run python plot_mlflow_backend.py
+
+      - name: Run examples
+        shell: bash
+        timeout-minutes: 15
+        run: |
+          set -e
+          for script in examples/*.py; do
+            echo "::group::${script}"
+            uv run python "${script}"
+            echo "::endgroup::"
+          done
+
+      - name: Upload debug artifacts on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ci-debug-${{ matrix.os }}-py${{ matrix.python-version }}
+          path: |
+            mlflow.db
+            mlruns/
+            *.py.stdout
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes #11

## Summary

New `.github/workflows/ci.yml` that runs the main script and every `examples/*.py` across a cross-platform matrix.

- **Triggers**: `push` (any branch) and `pull_request` (any target).
- **Matrix**: `ubuntu-latest`, `macos-latest`, `windows-latest` x Python `3.11`, `3.12` — six jobs, `fail-fast: false`.
- **Steps**: checkout -> `astral-sh/setup-uv@v6` (with `python-version` pinned to the matrix value) -> `actions/cache@v4` restoring `~/.cache/skrub` and `~/scikit_learn_data` with a 3-level restore-keys fallback -> `uv sync --frozen` -> `uv run python plot_mlflow_backend.py` (timeout 5 min) -> bash `for` loop over `examples/*.py` with `set -e` (timeout 15 min).
- **Shell**: `shell: bash` on every `run` step, so the glob and loop behave identically on Windows via Git Bash.
- **Debug artifacts**: on any prior failure (`if: failure()`), `actions/upload-artifact@v4` uploads `mlflow.db`, `mlruns/`, and any `*.py.stdout` under the name `ci-debug-<os>-py<version>` so failing runs are inspectable without a rerun.

Green/red will be proven by the first workflow run after merge — per the issue's acceptance criterion.

Part of epic #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)